### PR TITLE
Switch multi-term to cl-lib

### DIFF
--- a/site-lisp/extensions/lazycat/multi-term.el
+++ b/site-lisp/extensions/lazycat/multi-term.el
@@ -5,8 +5,8 @@
 ;; Copyright (C) 2008 ~ 2016 Andy Stewart, all rights reserved.
 ;; Copyright (C) 2010, ahei, all rights reserved.
 ;; Created: <2008-09-19 23:02:42>
-;; Version: 1.3
-;; Last-Updated: 2016-06-19 17:30:20
+;; Version: 1.4
+;; Last-Updated: 2017-03-03 13:48:38
 ;; URL: http://www.emacswiki.org/emacs/download/multi-term.el
 ;; Keywords: term, terminal, multiple buffer
 ;; Compatibility: GNU Emacs 23.2.1, GNU Emacs 24.4 (and prereleases)
@@ -28,7 +28,7 @@
 
 ;; Features that might be required by this library:
 ;;
-;;  `term' `cl' `advice'
+;;  `term' `cl-lib' `advice'
 ;;
 
 ;;; Commentary:
@@ -126,6 +126,9 @@
 ;;
 
 ;;; Change log:
+;;
+;; 2017/03/03
+;;      * Switch to cl-lib
 ;;
 ;; 2016/06/19
 ;;      * Add Hogren's patch: `term-send-delete-word' and binding to key 'M-d'.
@@ -268,7 +271,7 @@
 
 ;;; Require:
 (require 'term)
-(require 'cl)
+(require 'cl-lib)
 (require 'advice)
 
 ;;; Code:
@@ -697,7 +700,7 @@ If DIRECTION `PREVIOUS', switch to the previous term.
 Option OFFSET for skip OFFSET number term buffer."
   (if multi-term-buffer-list
       (let ((buffer-list-len (length multi-term-buffer-list))
-            (my-index (position (current-buffer) multi-term-buffer-list)))
+            (my-index (cl-position (current-buffer) multi-term-buffer-list)))
         (if my-index
             (let ((target-index (if (eq direction 'NEXT)
                                     (mod (+ my-index offset) buffer-list-len)
@@ -714,7 +717,7 @@ So this function unbinds some keys with `term-raw-map',
 and binds some keystroke with `term-raw-map'."
   (let (bind-key bind-command)
     ;; Unbind base key that conflict with user's keys-tokes.
-    (dolist (unbind-key term-unbind-key-list)
+    (cl-dolist (unbind-key term-unbind-key-list)
       (cond
        ((stringp unbind-key) (setq unbind-key (read-kbd-macro unbind-key)))
        ((vectorp unbind-key) nil)
@@ -723,7 +726,7 @@ and binds some keystroke with `term-raw-map'."
     ;; Add some i use keys.
     ;; If you don't like my keystroke,
     ;; just modified `term-bind-key-alist'
-    (dolist (element term-bind-key-alist)
+    (cl-dolist (element term-bind-key-alist)
       (setq bind-key (car element))
       (setq bind-command (cdr element))
       (cond
@@ -788,9 +791,9 @@ Otherwise return nil."
     (walk-windows
      (lambda (w)
        (with-selected-window w
-         (incf window-number)
+         (cl-incf window-number)
          (if (window-dedicated-p w)
-             (incf dedicated-window-number)))))
+             (cl-incf dedicated-window-number)))))
     (if (and (> dedicated-window-number 0)
              (= (- window-number dedicated-window-number) 1))
         t nil)))
@@ -802,7 +805,7 @@ Dedicated window can't deleted by command `delete-other-windows'."
   (let ((multi-term-dedicated-active-p (multi-term-window-exist-p multi-term-dedicated-window)))
     (if multi-term-dedicated-active-p
         (let ((current-window (selected-window)))
-          (dolist (win (window-list))
+          (cl-dolist (win (window-list))
             (when (and (window-live-p win)
                        (not (eq current-window win))
                        (not (window-dedicated-p win)))


### PR DESCRIPTION
This PR changes multi-term to use the cl-lib library instead of the deprecated cl library. cl-lib has been part of the standard Emacs distribution for almost four years, so I think it should be safe to make this change.